### PR TITLE
Adding the breaking change attributes

### DIFF
--- a/docs/breaking-changes.md
+++ b/docs/breaking-changes.md
@@ -1,0 +1,30 @@
+<!--
+    Please leave this section at the top of the breaking change documentation.
+
+    New breaking changes should go under the section titled "Future", and should adhere to the following format:
+
+    # Future
+
+    ## Release X.0.0
+
+    The following cmdlets were affected by this release:
+
+    **Cmdlet 1**
+    - Description of what has changed
+
+    ```powershell
+    # Old
+    # Sample of how the cmdlet was previously called
+
+    # New
+    # Sample of how the cmdlet should now be called
+    ```
+
+    With each release changes that are included will be moved from the section titled "Future" to the section titled "History" 
+-->
+
+# Breaking changes
+
+## Future
+
+## History

--- a/docs/breaking-defined.md
+++ b/docs/breaking-defined.md
@@ -1,0 +1,112 @@
+# Breaking Change Definition
+
+The introduction of breaking changes will impact how users can interact with the module, and often it will require the user invest additional effort. Through use of the [breaking change attribute](https://github.com/automationbrew/autobrew-powershell/blob/main/src/PowerShell/Attributes/BreakingChangeAttribute.cs) we can help minimize the disruption by providing advanced warning of any upcoming breaking change.
+
+## Surpressing the warning
+
+Automation Brew PowerShell provides the functionality to surpress the warning message for any breaking change. If you would like to disable this functionality, then utilize one of the following commands.
+
+```powershell
+# Disables breaking change warnings the current and future PowerShell sessions.
+Update-AbConfiguration -DisplayBreakingChanges $false -Scope Process 
+
+# Disables breaking change warnings for only the current PowerShell session.
+Update-AbConfiguration -DisplayBreakingChanges $false -Scope Process 
+```
+
+When this configuration is enabled no warning messages when be displayed when invoking commands. Disabling this functionality means you will not receive any advanced warning of breaking changes. In this circumstance it is recommended that you periodically review the [breaking changes](breaking-changes.md) documentation to gain insight into what will be changing.
+
+## Definitions
+
+### Commands
+
+* Change in the `OutputType` or removal of the `OutputType` attribute
+  * Before making the change update the command with the [OutputBreakingChangeAttribute]()
+* Changing a command name without an alias to the original name
+* Removing an attribute option such as `SupportsPaging` or `SupportShouldProcess`
+* Removing or changing a command alias
+
+## Examples
+
+### OutputBreakingChangeAttribute
+
+This attirbute should be used when the output type for a command will be changing. 
+
+#### Output type is changing
+
+```csharp
+[OutputBreakingChange(typeof(Foo), ReplacementOutputTypeName = "Dictionary<String, Foo>")]
+[Cmdlet(VerbsCommon.Get, "AbSomeObjectA"), OutputType(typeof(Foo))]
+public class GetAbSomeObjectA : ModuleCmdlet
+{
+    /// <summary>
+    /// Performs the actions associated with the command.
+    /// </summary>
+    protected override void PerformCmdlet()
+    {
+    }
+}
+```
+
+#### Effect at runtime
+
+```output
+Get-AbSomeObjectA <parms here>
+...
+Breaking changes in the cmdlet : Get-AbSomeObjectA
+ - The output type is changing from the existing type :'Foo' to the new type :'Dictionary<String, Foo>'
+```
+
+#### New properties are being added to the output type
+
+```csharp
+[OutputBreakingChange(typeof(Foo), NewOutputProperties = new String[] {"Prop1", "Prop2"})]
+[Cmdlet(VerbsCommon.Get, "AbSomeObjectA"), OutputType(typeof(Foo))]
+public class GetAbSomeObjectA : ModuleCmdlet
+{
+    /// <summary>
+    /// Performs the actions associated with the command.
+    /// </summary>
+    protected override void PerformCmdlet()
+    {
+    }
+}
+```
+
+#### Effect at runtime
+
+```output
+Get-AbSomeObjectA <parms here>
+...
+Breaking changes in the cmdlet : Get-AbSomeObjectA
+ - The output type 'Foo' is changing
+ - The following properties are being added to the output type :
+    'Prop1' 'Prop2'
+```
+
+#### Properties in the output type are being deprecated
+
+```csharp
+[OutputBreakingChange(typeof(Foo), DeprecatedOutputProperties = new String[] {"Prop3", "Prop4"})]
+[Cmdlet(VerbsCommon.Get, "AbSomeObjectA"), OutputType(typeof(Foo))]
+public class GetAbSomeObjectA : ModuleCmdlet
+{
+    /// <summary>
+    /// Performs the actions associated with the command.
+    /// </summary>
+    protected override void PerformCmdlet()
+    {
+    }
+}
+```
+
+#### Effect at runtime
+
+```output
+Get-AbSomeObjectA  <parms here>
+...
+Breaking changes in the cmdlet : Get-AbSomeObjectA
+ - The output type 'Foo' is changing
+ - The following properties in the output type are being deprecated :
+    'Prop3' 'Prop4'
+```

--- a/docs/help/Get-AbEnvironment.md
+++ b/docs/help/Get-AbEnvironment.md
@@ -1,7 +1,7 @@
 ---
 external help file: AutoBrew.PowerShell.dll-Help.xml
 Module Name: Ab
-online version: https://github.com/automationbrew/autobrew-powershell/blob/main/docs/help/Get-AbConfiguration.md
+online version: https://github.com/automationbrew/autobrew-powershell/blob/main/docs/help/Get-AbEnvironment.md
 schema: 2.0.0
 ---
 

--- a/src/Common/Properties/Resources.Designer.cs
+++ b/src/Common/Properties/Resources.Designer.cs
@@ -115,6 +115,205 @@ namespace AutoBrew.PowerShell.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to 
+        ///- The parameter : &apos;{0}&apos; is changing..
+        /// </summary>
+        public static string BreakingChangeAttributeParameterChanging {
+            get {
+                return ResourceManager.GetString("BreakingChangeAttributeParameterChanging", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to 
+        ///- The parameter : &apos;{0}&apos; is becoming mandatory..
+        /// </summary>
+        public static string BreakingChangeAttributeParameterMandatoryNow {
+            get {
+                return ResourceManager.GetString("BreakingChangeAttributeParameterMandatoryNow", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to 
+        ///- The parameter : &apos;{0}&apos; is being replaced by mandatory parameter : &apos;{1}&apos;..
+        /// </summary>
+        public static string BreakingChangeAttributeParameterReplaced {
+            get {
+                return ResourceManager.GetString("BreakingChangeAttributeParameterReplaced", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to 
+        ///- The parameter : &apos;{0}&apos; is being replaced by mandatory parameter : &apos;{1}&apos;..
+        /// </summary>
+        public static string BreakingChangeAttributeParameterReplacedMandatory {
+            get {
+                return ResourceManager.GetString("BreakingChangeAttributeParameterReplacedMandatory", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to 
+        ///The type of the parameter is changing from &apos;{0}&apos; to &apos;{1}&apos;..
+        /// </summary>
+        public static string BreakingChangeAttributeParameterTypeChange {
+            get {
+                return ResourceManager.GetString("BreakingChangeAttributeParameterTypeChange", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to 
+        ///- Change description : {0}.
+        /// </summary>
+        public static string BreakingChangesAttributesChangeDescriptionMessage {
+            get {
+                return ResourceManager.GetString("BreakingChangesAttributesChangeDescriptionMessage", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The cmdlet is being deprecated. There will be no replacement for it..
+        /// </summary>
+        public static string BreakingChangesAttributesCommandDeprecationMessageNoReplacement {
+            get {
+                return ResourceManager.GetString("BreakingChangesAttributesCommandDeprecationMessageNoReplacement", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The cmdlet &apos;{0}&apos; is replacing this cmdlet..
+        /// </summary>
+        public static string BreakingChangesAttributesCommandDeprecationMessageWithReplacement {
+            get {
+                return ResourceManager.GetString("BreakingChangesAttributesCommandDeprecationMessageWithReplacement", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to {0}.
+        /// </summary>
+        public static string BreakingChangesAttributesDeclarationMessage {
+            get {
+                return ResourceManager.GetString("BreakingChangesAttributesDeclarationMessage", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to 
+        ///- Cmdlet : &apos;{0}&apos;
+        /// - {1}.
+        /// </summary>
+        public static string BreakingChangesAttributesDeclarationMessageWithCmdletName {
+            get {
+                return ResourceManager.GetString("BreakingChangesAttributesDeclarationMessageWithCmdletName", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to 
+        ///Note : Go to {0} for steps to suppress this breaking change warning, and other information on breaking changes..
+        /// </summary>
+        public static string BreakingChangesAttributesFooterMessage {
+            get {
+                return ResourceManager.GetString("BreakingChangesAttributesFooterMessage", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Upcoming breaking changes in the cmdlet &apos;{0}&apos; :.
+        /// </summary>
+        public static string BreakingChangesAttributesHeaderMessage {
+            get {
+                return ResourceManager.GetString("BreakingChangesAttributesHeaderMessage", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to 
+        ///- This change will take effect on &apos;{0}&apos;.
+        /// </summary>
+        public static string BreakingChangesAttributesInEffectByDateMessage {
+            get {
+                return ResourceManager.GetString("BreakingChangesAttributesInEffectByDateMessage", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to 
+        ///- The change is expected to take effect from the version : &apos;{0}&apos;.
+        /// </summary>
+        public static string BreakingChangesAttributesInEffectByVersion {
+            get {
+                return ResourceManager.GetString("BreakingChangesAttributesInEffectByVersion", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to 
+        ///- The output type is changing from the existing type :&apos;{0}&apos; to the new type :&apos;{1}&apos;.
+        /// </summary>
+        public static string BreakingChangesAttributesOutputChange1 {
+            get {
+                return ResourceManager.GetString("BreakingChangesAttributesOutputChange1", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to 
+        ///- The output type &apos;{0}&apos; is changing.
+        /// </summary>
+        public static string BreakingChangesAttributesOutputChange2 {
+            get {
+                return ResourceManager.GetString("BreakingChangesAttributesOutputChange2", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to 
+        ///- The following properties are being added to the output type :.
+        /// </summary>
+        public static string BreakingChangesAttributesOutputPropertiesAdded {
+            get {
+                return ResourceManager.GetString("BreakingChangesAttributesOutputPropertiesAdded", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to 
+        ///- The following properties in the output type are being deprecated :.
+        /// </summary>
+        public static string BreakingChangesAttributesOutputPropertiesRemoved {
+            get {
+                return ResourceManager.GetString("BreakingChangesAttributesOutputPropertiesRemoved", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to 
+        ///The output type &apos;{0}&apos; is being deprecated without a replacement..
+        /// </summary>
+        public static string BreakingChangesAttributesOutputTypeDeprecated {
+            get {
+                return ResourceManager.GetString("BreakingChangesAttributesOutputTypeDeprecated", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to 
+        ///Cmdlet invocation changes :
+        ///    Old Way : {0}
+        ///    New Way : {1}.
+        /// </summary>
+        public static string BreakingChangesAttributesUsageChangeMessageConsole {
+            get {
+                return ResourceManager.GetString("BreakingChangesAttributesUsageChangeMessageConsole", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Controls if data collection, to help improve Automation Brew cmdlets, is enabled. When enabled, telemetry is shared with the developers to identify patterns of usage to identify common issues and help improve the experience with the module. Automation Brew does not collect any personal or private information. This configuration is enabled by default, and you must opt-out if you which to disable this functionality..
         /// </summary>
         public static string DataCollectionConfigurationDefinition {
@@ -129,6 +328,15 @@ namespace AutoBrew.PowerShell.Properties {
         public static string DisconnectAccountTarget {
             get {
                 return ResourceManager.GetString("DisconnectAccountTarget", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Controls if warning messages for breaking changes are displayed or suppressed. When enabled, a breaking change warning is displayed when executing cmdlets with breaking changes in a future release..
+        /// </summary>
+        public static string DisplayBreakingChangesConfigurationDefinition {
+            get {
+                return ResourceManager.GetString("DisplayBreakingChangesConfigurationDefinition", resourceCulture);
             }
         }
         

--- a/src/Common/Properties/Resources.resx
+++ b/src/Common/Properties/Resources.resx
@@ -135,11 +135,93 @@
   <data name="AssertStringNotEmptyInvalidPrefix" xml:space="preserve">
     <value>string</value>
   </data>
+  <data name="BreakingChangeAttributeParameterChanging" xml:space="preserve">
+    <value>
+- The parameter : '{0}' is changing.</value>
+  </data>
+  <data name="BreakingChangeAttributeParameterMandatoryNow" xml:space="preserve">
+    <value>
+- The parameter : '{0}' is becoming mandatory.</value>
+  </data>
+  <data name="BreakingChangeAttributeParameterReplaced" xml:space="preserve">
+    <value>
+- The parameter : '{0}' is being replaced by mandatory parameter : '{1}'.</value>
+  </data>
+  <data name="BreakingChangeAttributeParameterReplacedMandatory" xml:space="preserve">
+    <value>
+- The parameter : '{0}' is being replaced by mandatory parameter : '{1}'.</value>
+  </data>
+  <data name="BreakingChangeAttributeParameterTypeChange" xml:space="preserve">
+    <value>
+The type of the parameter is changing from '{0}' to '{1}'.</value>
+  </data>
+  <data name="BreakingChangesAttributesChangeDescriptionMessage" xml:space="preserve">
+    <value>
+- Change description : {0}</value>
+  </data>
+  <data name="BreakingChangesAttributesCommandDeprecationMessageNoReplacement" xml:space="preserve">
+    <value>The cmdlet is being deprecated. There will be no replacement for it.</value>
+  </data>
+  <data name="BreakingChangesAttributesCommandDeprecationMessageWithReplacement" xml:space="preserve">
+    <value>The cmdlet '{0}' is replacing this cmdlet.</value>
+  </data>
+  <data name="BreakingChangesAttributesDeclarationMessage" xml:space="preserve">
+    <value>{0}</value>
+  </data>
+  <data name="BreakingChangesAttributesDeclarationMessageWithCmdletName" xml:space="preserve">
+    <value>
+- Cmdlet : '{0}'
+ - {1}</value>
+  </data>
+  <data name="BreakingChangesAttributesFooterMessage" xml:space="preserve">
+    <value>
+Note : Go to {0} for steps to suppress this breaking change warning, and other information on breaking changes.</value>
+  </data>
+  <data name="BreakingChangesAttributesHeaderMessage" xml:space="preserve">
+    <value>Upcoming breaking changes in the cmdlet '{0}' :</value>
+  </data>
+  <data name="BreakingChangesAttributesInEffectByDateMessage" xml:space="preserve">
+    <value>
+- This change will take effect on '{0}'</value>
+  </data>
+  <data name="BreakingChangesAttributesInEffectByVersion" xml:space="preserve">
+    <value>
+- The change is expected to take effect from the version : '{0}'</value>
+  </data>
+  <data name="BreakingChangesAttributesOutputChange1" xml:space="preserve">
+    <value>
+- The output type is changing from the existing type :'{0}' to the new type :'{1}'</value>
+  </data>
+  <data name="BreakingChangesAttributesOutputChange2" xml:space="preserve">
+    <value>
+- The output type '{0}' is changing</value>
+  </data>
+  <data name="BreakingChangesAttributesOutputPropertiesAdded" xml:space="preserve">
+    <value>
+- The following properties are being added to the output type :</value>
+  </data>
+  <data name="BreakingChangesAttributesOutputPropertiesRemoved" xml:space="preserve">
+    <value>
+- The following properties in the output type are being deprecated :</value>
+  </data>
+  <data name="BreakingChangesAttributesOutputTypeDeprecated" xml:space="preserve">
+    <value>
+The output type '{0}' is being deprecated without a replacement.</value>
+  </data>
+  <data name="BreakingChangesAttributesUsageChangeMessageConsole" xml:space="preserve">
+    <value>
+Cmdlet invocation changes :
+    Old Way : {0}
+    New Way : {1}</value>
+  </data>
   <data name="DataCollectionConfigurationDefinition" xml:space="preserve">
     <value>Controls if data collection, to help improve Automation Brew cmdlets, is enabled. When enabled, telemetry is shared with the developers to identify patterns of usage to identify common issues and help improve the experience with the module. Automation Brew does not collect any personal or private information. This configuration is enabled by default, and you must opt-out if you which to disable this functionality.</value>
   </data>
   <data name="DisconnectAccountTarget" xml:space="preserve">
     <value>remove account</value>
+  </data>
+  <data name="DisplayBreakingChangesConfigurationDefinition" xml:space="preserve">
+    <value>Controls if warning messages for breaking changes are displayed or suppressed. When enabled, a breaking change warning is displayed when executing cmdlets with breaking changes in a future release.</value>
   </data>
   <data name="LogoutTarget" xml:space="preserve">
     <value>Logout account '{0}'</value>

--- a/src/PowerShell/Attributes/BreakingChangeAttribute.cs
+++ b/src/PowerShell/Attributes/BreakingChangeAttribute.cs
@@ -1,0 +1,189 @@
+﻿namespace AutoBrew.PowerShell
+{
+    using System.Management.Automation;
+    using System.Globalization;
+    using Properties;
+
+    /// <summary>
+    /// Attribute used by classes that inherit the <see cref="Commands.ModuleCmdlet" /> class to define a breaking change.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Class | AttributeTargets.Field | AttributeTargets.Property, AllowMultiple = true)]
+    internal class BreakingChangeAttribute : Attribute
+    {
+        /// <summary>
+        /// The message that describes the breaking change.
+        /// </summary>
+        private readonly string message;
+
+        /// <summary>
+        /// Gets or sets the description for the change.
+        /// </summary>
+        public string ChangeDescription { get; set; }
+
+        /// <summary>
+        /// Gets the date the change will be required.
+        /// </summary>
+        public DateTime? ChangeInEfectByDate { get; } = null;
+
+        /// <summary>
+        /// Gets the version when this change will be depcreated.
+        /// </summary>
+        public string DeprecateByVersion { get; }
+
+        /// <summary>
+        /// Gets or sets the new way the command should be invoked.
+        /// </summary>
+        public string NewWay { get; set; }
+
+        /// <summary>
+        /// Gets or sets the old way the command was invoked.
+        /// </summary>
+        public string OldWay { get; set; }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="BreakingChangeAttribute" /> class.
+        /// </summary>
+        /// <param name="message">The message that describes the breaking change.</param>
+        protected BreakingChangeAttribute(string message)
+        {
+            message.AssertNotEmpty(nameof(message));
+
+            this.message = message;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="BreakingChangeAttribute" /> class.
+        /// </summary>
+        /// <param name="message">The message that describes the breaking change.</param>
+        /// <param name="deprecateByVersion">The version where the change will be required.</param>
+        protected BreakingChangeAttribute(string message, string deprecateByVersion)
+        {
+            message.AssertNotEmpty(nameof(message));
+            deprecateByVersion.AssertNotEmpty(nameof(deprecateByVersion));
+
+            this.message = message;
+            DeprecateByVersion = deprecateByVersion;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="BreakingChangeAttribute" /> class.
+        /// </summary>
+        /// <param name="message">The message that describes the breaking change.</param>
+        /// <param name="deprecateByVersion">The version where the change will be required.</param>
+        /// <param name="changeInEfectByDate">The date when the change will be required.</param>
+        protected BreakingChangeAttribute(string message, string deprecateByVersion, string changeInEfectByDate)
+        {
+            deprecateByVersion.AssertNotEmpty(nameof(deprecateByVersion));
+            changeInEfectByDate.AssertNotEmpty(nameof(changeInEfectByDate));
+
+            this.message = message;
+            DeprecateByVersion = deprecateByVersion;
+            ChangeInEfectByDate = DateTime.Parse(changeInEfectByDate, CultureInfo.CurrentCulture);
+        }
+
+        /// <summary>
+        /// Gets the specified message for the attribute.
+        /// </summary>
+        /// <returns>The specified message for the attribute.</returns>
+        protected virtual string GetAttributeSpecificMessage()
+        {
+            return message;
+        }
+
+        /// <summary>
+        /// Gets the name of the command from the type.
+        /// </summary>
+        /// <param name="type">The type for the command being invoked.</param>
+        /// <returns>The name of the command from the type.</returns>
+        public static string GetNameFromCmdletType(Type type)
+        {
+            type.AssertNotNull(nameof(type));
+
+            string cmdletName = null;
+            CmdletAttribute cmdletAttrib = (CmdletAttribute)type.GetCustomAttributes(typeof(CmdletAttribute), false).FirstOrDefault();
+
+            if (cmdletAttrib != null)
+            {
+                cmdletName = $"{cmdletAttrib.VerbName}-{cmdletAttrib.NounName}";
+            }
+
+            return cmdletName;
+        }
+
+        /// <summary>
+        /// Checks if the breaking change applies to how or where the command was invoked.
+        /// </summary>
+        /// <param name="invocationInfo">The description of how and where this command was invoked.</param>
+        /// <returns>
+        /// <c>true</c> if the breaking change applies to how or where the command was invoked; otherwise <c>false</c>.
+        /// </returns>
+        public virtual bool IsApplicableToInvocation(InvocationInfo invocationInfo)
+        {
+            return true;
+        }
+
+        /// <summary>
+        /// Writes the attribute information to the output.
+        /// </summary>
+        /// <param name="type">The type for the command being invoked.</param>
+        /// <param name="withCmdletName">A flag indicating whether or not to write the command name.</param>
+        /// <param name="output">The action used to write the output.</param>
+        public void PrintCustomAttributeInfo(Type type, bool withCmdletName, Action<string> output)
+        {
+            if (withCmdletName == false)
+            {
+                output(
+                    string.Format(
+                        CultureInfo.CurrentCulture,
+                        Resources.BreakingChangesAttributesDeclarationMessage,
+                        GetAttributeSpecificMessage()));
+            }
+            else
+            {
+                output(
+                    string.Format(
+                        CultureInfo.CurrentCulture,
+                        Resources.BreakingChangesAttributesDeclarationMessageWithCmdletName,
+                        GetNameFromCmdletType(type),
+                        GetAttributeSpecificMessage()));
+            }
+
+            if (!string.IsNullOrWhiteSpace(ChangeDescription))
+            {
+                output(
+                    string.Format(
+                        CultureInfo.CurrentCulture,
+                        Resources.BreakingChangesAttributesChangeDescriptionMessage,
+                        ChangeDescription));
+            }
+
+            if (ChangeInEfectByDate.HasValue)
+            {
+                output(
+                    string.Format(
+                        CultureInfo.CurrentCulture,
+                        Resources.BreakingChangesAttributesInEffectByDateMessage,
+                        ChangeInEfectByDate.Value));
+            }
+
+            if (!string.IsNullOrEmpty(DeprecateByVersion))
+            {
+                output(
+                    string.Format(
+                        CultureInfo.CurrentCulture,
+                        Resources.BreakingChangesAttributesInEffectByVersion,
+                        DeprecateByVersion));
+            }
+
+            if (OldWay != null && NewWay != null)
+            {
+                output(
+                    string.Format(
+                        CultureInfo.CurrentCulture,
+                        Resources.BreakingChangesAttributesUsageChangeMessageConsole,
+                        OldWay,
+                        NewWay));
+            }
+        }
+    }
+}

--- a/src/PowerShell/Attributes/CommandDeprecationAttribute.cs
+++ b/src/PowerShell/Attributes/CommandDeprecationAttribute.cs
@@ -1,0 +1,56 @@
+﻿namespace AutoBrew.PowerShell
+{
+    using Properties;
+
+    /// <summary>
+    /// Attribute used by classes that inherit the <see cref="Commands.ModuleCmdlet" /> class to inform the user a command is being deprecated.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Class)]
+    internal sealed class CommandDeprecationAttribute : BreakingChangeAttribute
+    {
+        /// <summary>
+        /// Gets or sets the name for the replacement command.
+        /// </summary>
+        public string ReplacementCmdletName { get; set; }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="CommandDeprecationAttribute" /> class.
+        /// </summary>
+        public CommandDeprecationAttribute() : base(string.Empty)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="CommandDeprecationAttribute" /> class.
+        /// </summary>
+        /// <param name="deprecateByVersion">The version where the change will be required.</param>
+        public CommandDeprecationAttribute(string deprecateByVersion) :
+             base(string.Empty, deprecateByVersion)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="CommandDeprecationAttribute" /> class.
+        /// </summary>
+        /// <param name="deprecateByVersion">The version where the change will be required.</param>
+        /// <param name="changeInEfectByDate">The date when the change will be required.</param>
+        public CommandDeprecationAttribute(string deprecateByVersion, string changeInEfectByDate) :
+             base(string.Empty, deprecateByVersion, changeInEfectByDate)
+        {
+        }
+
+        /// <summary>
+        /// Gets the specified message for the attribute.
+        /// </summary>
+        /// <returns>The specified message for the attribute.</returns>
+        protected override string GetAttributeSpecificMessage()
+        {
+            if (string.IsNullOrEmpty(ReplacementCmdletName))
+            {
+                return Resources.BreakingChangesAttributesCommandDeprecationMessageNoReplacement;
+            }
+
+            return string.Format(Resources.BreakingChangesAttributesCommandDeprecationMessageWithReplacement, ReplacementCmdletName);
+        }
+    }
+}

--- a/src/PowerShell/Attributes/OutputBreakingChangeAttribute.cs
+++ b/src/PowerShell/Attributes/OutputBreakingChangeAttribute.cs
@@ -1,0 +1,111 @@
+﻿namespace AutoBrew.PowerShell
+{
+    using System.Text;
+    using Properties;
+
+    /// <summary>
+    /// Attribute used by classes that inherit the <see cref="Commands.ModuleCmdlet" /> class to define a breaking change with the output.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Class, AllowMultiple = true)]
+    internal sealed class OutputBreakingChangeAttribute : BreakingChangeAttribute
+    {
+        /// <summary>
+        /// Gets or sets the output properties that will be depcreated.
+        /// </summary>
+        public string[] DeprecatedOutputProperties { get; set; }
+
+        /// <summary>
+        /// Gets the output type that will be depcreated.
+        /// </summary>
+        public Type DeprecatedOutputType { get; }
+
+        /// <summary>
+        /// Gets or sets the new properties that will be introduced.
+        /// </summary>
+        public string[] NewOutputProperties { get; set; }
+
+        /// <summary>
+        /// Gets or sets the name of the replacement output type.
+        /// </summary>
+        public string ReplacementOutputTypeName { get; set; }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="OutputBreakingChangeAttribute" /> class.
+        /// </summary>
+        /// <param name="deprecatedOutputType">The type for the output type that will be deprecated.</param>
+        public OutputBreakingChangeAttribute(Type deprecatedOutputType) : base(string.Empty)
+        {
+            DeprecatedOutputType = deprecatedOutputType;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="OutputBreakingChangeAttribute" /> class.
+        /// </summary>
+        /// <param name="deprecatedOutputType">The type for the output type that will be deprecated.</param>
+        /// <param name="deprecateByVersion">The version where the change will be required.</param>
+        public OutputBreakingChangeAttribute(Type deprecatedOutputType, string deprecateByVersion) :
+            base(string.Empty, deprecateByVersion)
+        {
+            DeprecatedOutputType = deprecatedOutputType;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="OutputBreakingChangeAttribute" /> class.
+        /// </summary>
+        /// <param name="deprecatedOutputType">The type for the output type that will be deprecated.</param>
+        /// <param name="deprecateByVersion">The version where the change will be required.</param>
+        /// <param name="changeInEfectByDate">The date when the change will be required.</param>
+        public OutputBreakingChangeAttribute(Type deprecatedOutputType, string deprecateByVersion, string changeInEfectByDate) :
+            base(string.Empty, deprecateByVersion, changeInEfectByDate)
+        {
+            DeprecatedOutputType = deprecatedOutputType;
+        }
+
+        /// <summary>
+        /// Gets the specified message for the attribute.
+        /// </summary>
+        /// <returns>The specified message for the attribute.</returns>
+        protected override string GetAttributeSpecificMessage()
+        {
+            StringBuilder message = new();
+
+            if (DeprecatedOutputProperties == null && NewOutputProperties == null && string.IsNullOrEmpty(ChangeDescription) && string.IsNullOrEmpty(ReplacementOutputTypeName))
+            {
+                message.Append(string.Format(Resources.BreakingChangesAttributesOutputTypeDeprecated, DeprecatedOutputType.FullName));
+            }
+            else
+            {
+                if (string.IsNullOrEmpty(ReplacementOutputTypeName) == false)
+                {
+                    message.Append(string.Format(Resources.BreakingChangesAttributesOutputChange1, DeprecatedOutputType.FullName, ReplacementOutputTypeName));
+                }
+                else
+                {
+                    message.Append(string.Format(Resources.BreakingChangesAttributesOutputChange2, DeprecatedOutputType.FullName));
+                }
+
+                if (DeprecatedOutputProperties != null && DeprecatedOutputProperties.Length > 0)
+                {
+                    message.Append(Resources.BreakingChangesAttributesOutputPropertiesRemoved);
+
+                    foreach (string property in DeprecatedOutputProperties)
+                    {
+                        message.Append($" '{property}'");
+                    }
+                }
+
+                if (NewOutputProperties != null && NewOutputProperties.Length > 0)
+                {
+                    message.Append(Resources.BreakingChangesAttributesOutputPropertiesAdded);
+
+                    foreach (string property in NewOutputProperties)
+                    {
+                        message.Append($" '{property}'");
+                    }
+                }
+            }
+
+            return message.ToString();
+        }
+    }
+}

--- a/src/PowerShell/Attributes/ParameterBreakingChangeAttribute.cs
+++ b/src/PowerShell/Attributes/ParameterBreakingChangeAttribute.cs
@@ -1,0 +1,123 @@
+﻿namespace AutoBrew.PowerShell
+{
+    using System.Management.Automation;
+    using System.Text;
+    using Properties;
+
+    /// <summary>
+    /// Attribute used by fields and properties in classes that inherit the <see cref="Commands.ModuleCmdlet" /> class to define a breaking change for a parameter.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Field | AttributeTargets.Property, AllowMultiple = true)]
+    internal class ParameterBreakingChangeAttribute : BreakingChangeAttribute
+    {
+        /// <summary>
+        /// Gets or sets the flag that indicates if the parameter is becoming mandatory.
+        /// </summary>
+        public bool IsBecomingMandatory { get; set; }
+
+        /// <summary>
+        /// Gets or sets the name for the new parameter type.
+        /// </summary>
+        public string NewParameterTypeName { get; set; }
+
+        /// <summary>
+        /// Gets or sets the type for the old parameter.
+        /// </summary>
+        public Type OldParamaterType { get; set; }
+
+        /// <summary>
+        /// Gets or sets the paramter that is changing.
+        /// </summary>
+        public string ParameterChanging { get; }
+
+        /// <summary>
+        /// Gets or sets the name for the replacement parameter.
+        /// </summary>
+        public string ReplacementParameterName { get; set; }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ParameterBreakingChangeAttribute" /> class.
+        /// </summary>
+        /// <param name="parameterChanging">The parameter on the command that is changing.</param>
+        public ParameterBreakingChangeAttribute(string parameterChanging) : base(string.Empty)
+        {
+            ParameterChanging = parameterChanging;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ParameterBreakingChangeAttribute" /> class.
+        /// </summary>
+        /// <param name="parameterChanging">The parameter on the command that is changing.</param>
+        /// <param name="deprecateByVersion">The version where the change will be required.</param>
+        public ParameterBreakingChangeAttribute(string parameterChanging, string deprecateByVersion) :
+            base(string.Empty, deprecateByVersion)
+        {
+            ParameterChanging = parameterChanging;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ParameterBreakingChangeAttribute" /> class.
+        /// </summary>
+        /// <param name="parameterChanging">The parameter on the command that is changing.</param>
+        /// <param name="deprecateByVersion">The version where the change will be required.</param>
+        /// <param name="changeInEfectByDate">The date when the change will be required.</param>
+        public ParameterBreakingChangeAttribute(string parameterChanging, string deprecateByVersion, string changeInEfectByDate) :
+             base(string.Empty, deprecateByVersion, changeInEfectByDate)
+        {
+            ParameterChanging = parameterChanging;
+        }
+
+        /// <summary>
+        /// Gets the specified message for the attribute.
+        /// </summary>
+        /// <returns>The specified message for the attribute.</returns>
+        protected override string GetAttributeSpecificMessage()
+        {
+            StringBuilder message = new();
+
+            if (string.IsNullOrEmpty(ReplacementParameterName) == false)
+            {
+                if (IsBecomingMandatory)
+                {
+                    message.Append(string.Format(Resources.BreakingChangeAttributeParameterReplacedMandatory, ParameterChanging, ReplacementParameterName));
+                }
+                else
+                {
+                    message.Append(string.Format(Resources.BreakingChangeAttributeParameterReplaced, ParameterChanging, ReplacementParameterName));
+                }
+            }
+            else
+            {
+                if (IsBecomingMandatory)
+                {
+                    message.Append(string.Format(Resources.BreakingChangeAttributeParameterMandatoryNow, ParameterChanging));
+                }
+                else
+                {
+                    message.Append(string.Format(Resources.BreakingChangeAttributeParameterChanging, ParameterChanging));
+                }
+            }
+
+            if (OldParamaterType != null && string.IsNullOrEmpty(NewParameterTypeName) == false)
+            {
+                message.Append(string.Format(Resources.BreakingChangeAttributeParameterTypeChange, OldParamaterType.FullName, NewParameterTypeName));
+            }
+
+            return message.ToString();
+        }
+
+        /// <summary>
+        /// Checks if the breaking change applies to how or where the command was invoked.
+        /// </summary>
+        /// <param name="invocationInfo">The description of how and where this command was invoked.</param>
+        /// <returns>
+        /// <c>true</c> if the breaking change applies to how or where the command was invoked; otherwise <c>false</c>.
+        /// </returns>
+        public override bool IsApplicableToInvocation(InvocationInfo invocationInfo)
+        {
+            bool? applicable = invocationInfo == null ? true : invocationInfo.BoundParameters?.Keys?.Contains(ParameterChanging);
+
+            return applicable ?? false;
+        }
+    }
+}

--- a/src/PowerShell/Commands/ConnectAbAccount.cs
+++ b/src/PowerShell/Commands/ConnectAbAccount.cs
@@ -117,7 +117,7 @@
             }
 
             await ConfirmActionAsync(
-                string.Format(CultureInfo.InvariantCulture, Resources.AcquireTokenTarget, account.AccountType, Environment),
+                string.Format(CultureInfo.InvariantCulture, Resources.AcquireTokenTarget, account.AccountType, environment.Name),
                 "acquire token",
                 async () =>
                 {

--- a/src/PowerShell/Commands/ModuleInitializer.cs
+++ b/src/PowerShell/Commands/ModuleInitializer.cs
@@ -60,6 +60,12 @@
             IConfigurationProvider provider = ConfigurationProvider.Initialize();
 
             provider.RegisterDefinition(new TypedConfigurationDefinition<bool>(
+                ConfigurationCategory.Module,
+                true,
+                Resources.DisplayBreakingChangesConfigurationDefinition,
+                ConfigurationKey.DisplayBreakingChanges));
+
+            provider.RegisterDefinition(new TypedConfigurationDefinition<bool>(
                 ConfigurationCategory.Telemetry,
                 true,
                 Resources.DataCollectionConfigurationDefinition,

--- a/src/PowerShell/Commands/NewAbAccessToken.cs
+++ b/src/PowerShell/Commands/NewAbAccessToken.cs
@@ -42,7 +42,7 @@
         /// <summary>
         /// Gets or sets the identifier for the application to be used for authentication.
         /// </summary>
-        [Parameter(HelpMessage = "The identifier for the application to be used for authentication.", Mandatory = true)]
+        [Parameter(HelpMessage = "The identifier for the application to be used for authentication.", Mandatory = false)]
         [ValidatePattern(@"^(\{){0,1}[0-9a-fA-F]{8}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{12}(\}){0,1}$", Options = RegexOptions.Compiled | RegexOptions.IgnoreCase)]
         public string ApplicationId { get; set; }
 
@@ -100,7 +100,10 @@
 
             ModuleSession.Instance.TryGetEnvironment(Environment, out ModuleEnvironment environment);
 
-            account.SetProperty(ExtendedPropertyType.ApplicationId, ApplicationId);
+            if (string.IsNullOrEmpty(ApplicationId) == false)
+            {
+                account.SetProperty(ExtendedPropertyType.ApplicationId, ApplicationId);
+            }
 
             if (ParameterSetName.Equals(DefaultParameterSetName))
             {

--- a/src/PowerShell/Models/Configuration/ConfigurationCategory.cs
+++ b/src/PowerShell/Models/Configuration/ConfigurationCategory.cs
@@ -6,6 +6,11 @@
     internal static class ConfigurationCategory
     {
         /// <summary>
+        /// The category for all configurations that do not have a specific categorization.
+        /// </summary>
+        public const string Module = "Module";
+
+        /// <summary>
         /// The category for all configurations related to telemetry.
         /// </summary>
         public const string Telemetry = "Telemetry";

--- a/src/PowerShell/Models/Configuration/ConfigurationKey.cs
+++ b/src/PowerShell/Models/Configuration/ConfigurationKey.cs
@@ -9,5 +9,10 @@
         /// The key for the data collection configuration.
         /// </summary>
         public const string DataCollection = "DataCollection";
+
+        /// <summary>
+        /// The key for the display breaking changes configuration.
+        /// </summary>
+        public const string DisplayBreakingChanges = "DisplayBreakingChanges";
     }
 }


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

## Description

Through this pull request new attributes are being added to support breaking changes.

## Checklist

- [x] I have read the [submitting changes](../CONTRIBUTING.md#submitting-changes) section from the [contributing](../CONTRIBUTING.md) article.
- [x] Updates have been made to the [change log](../CHANGELOG.md) that reflect what is changing.
  - A snippet outlining the change(s) made in the PR should be written under the `## Upcoming release` header -- no new version header should be added.
- [x] When applicable, if the changes in this pull request are introducing breaking changes, as defined [here](../docs/breaking-defined.md), the following has been completed:
  - [x] Details for the breaking change have been documented under the `## Future` header in the [breaking changes](../docs/breaking-changes.md) article.
  - [x] The appropriate breaking change attributes have been implemented.
- [x] When applicable, the markdown help has been regenerated using the process documented [here](../docs/help-generation.md#updating-all-markdown-files-in-a-module)
- [ ] When applicable, the changes made in the pull request have proper test coverage.
