### PR TITLE
More breaking change examples

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -6,7 +6,7 @@
 
 ## Checklist
 
-- [ ] I have read the [submitting changes(../blob/main/CONTRIBUTING.md#submitting-changes) section from the [contributing](../blob/main/CONTRIBUTING.md) article.
+- [ ] I have read the [submitting changes](../blob/main/CONTRIBUTING.md#submitting-changes) section from the [contributing](../blob/main/CONTRIBUTING.md) article.
 - [ ] Updates have been made to the [change log](../blob/main/CHANGELOG.md) that reflect what is changing.
   - A snippet outlining the change(s) made in the PR should be written under the `## Upcoming release` header -- no new version header should be added.
 - [ ] When applicable, if the changes in this pull request are introducing breaking changes, as defined [here](../blob/main/docs/breaking-defined.md), the following has been completed:

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -6,11 +6,11 @@
 
 ## Checklist
 
-- [ ] I have read the [submitting changes](../CONTRIBUTING.md#submitting-changes) section from the [contributing](../CONTRIBUTING.md) article.
-- [ ] Updates have been made to the [change log](../CHANGELOG.md) that reflect what is changing.
+- [ ] I have read the [submitting changes(../blob/main/CONTRIBUTING.md#submitting-changes) section from the [contributing](../blob/main/CONTRIBUTING.md) article.
+- [ ] Updates have been made to the [change log](../blob/main/CHANGELOG.md) that reflect what is changing.
   - A snippet outlining the change(s) made in the PR should be written under the `## Upcoming release` header -- no new version header should be added.
-- [ ] When applicable, if the changes in this pull request are introducing breaking changes, as defined [here](../docs/breaking-defined.md), the following has been completed:
-  - [ ] Details for the breaking change have been documented under the `## Future` header in the [breaking changes](../docs/breaking-changes.md) article.
+- [ ] When applicable, if the changes in this pull request are introducing breaking changes, as defined [here](../blob/main/docs/breaking-defined.md), the following has been completed:
+  - [ ] Details for the breaking change have been documented under the `## Future` header in the [breaking changes](../blob/main/docs/breaking-changes.md) article.
   - [ ] The appropriate breaking change attributes have been implemented.
-- [ ] When applicable, the markdown help has been regenerated using the process documented [here](../docs/help-generation.md#updating-all-markdown-files-in-a-module)
+- [ ] When applicable, the markdown help has been regenerated using the process documented [here](../blob/main/docs/help-generation.md#updating-all-markdown-files-in-a-module)
 - [ ] When applicable, the changes made in the pull request have proper test coverage.

--- a/docs/breaking-defined.md
+++ b/docs/breaking-defined.md
@@ -8,7 +8,7 @@ Automation Brew PowerShell provides the functionality to surpress the warning me
 
 ```powershell
 # Disables breaking change warnings the current and future PowerShell sessions.
-Update-AbConfiguration -DisplayBreakingChanges $false -Scope Process 
+Update-AbConfiguration -DisplayBreakingChanges $false -Scope CurrentUser 
 
 # Disables breaking change warnings for only the current PowerShell session.
 Update-AbConfiguration -DisplayBreakingChanges $false -Scope Process 
@@ -53,6 +53,34 @@ When this configuration is enabled no warning messages when be displayed when in
 
 This attribute should be used when making a breaking change that is not handled by one of the specialized attributes below.
 
+#### Behavioral change
+
+```csharp
+[BreakingChange("Adding the new mandatory parameter Category.", NewWay = "Get-AbSomeObjectA -Category Food", OldWay = "Get-AbSomeObjectA")]
+[Cmdlet(VerbsCommon.Get, "AbSomeObjectA"), OutputType(typeof(Foo))]
+public class GetAbSomeObjectA : ModuleCmdlet
+{
+    /// <summary>
+    /// Performs the actions associated with the command.
+    /// </summary>
+    protected override void PerformCmdlet()
+    {
+    }
+}
+```
+
+##### Effect at runtime
+
+```output
+Get-AbSomeObjectA <parms here>
+
+Breaking changes in the cmdlet : Get-AbSomeObjectA
+ - Adding the new mandatory parameter Category.
+Cmdlet invocation changes :
+    Old Way : Get-AbSomeObjectA
+    New Way : Get-AbSomeObjectA -Category Food
+```
+
 #### Simple message
 
 ```csharp
@@ -69,7 +97,7 @@ public class GetAbSomeObjectA : ModuleCmdlet
 }
 ```
 
-#### Effect at runtime
+##### Effect at runtime
 
 ```output
 Get-AbSomeObjectA <parms here>
@@ -94,7 +122,7 @@ public class GetAbSomeObjectA : ModuleCmdlet
 }
 ```
 
-#### Effect at runtime
+##### Effect at runtime
 
 ```output
 Get-AbSomeObjectA <parms here>
@@ -120,7 +148,7 @@ public class GetAbSomeObjectA : ModuleCmdlet
 }
 ```
 
-#### Effect at runtime
+##### Effect at runtime
 
 ```output
 Get-AbSomeObjectA <parms here>
@@ -151,7 +179,7 @@ public class GetAbSomeObjectA : ModuleCmdlet
 }
 ```
 
-#### Effect at runtime
+##### Effect at runtime
 
 ```output
 Get-AbSomeObjectA <parms here>
@@ -176,7 +204,7 @@ public class GetAbSomeObjectA : ModuleCmdlet
 }
 ```
 
-#### Effect at runtime
+##### Effect at runtime
 
 ```output
 Get-AbSomeObjectA <parms here>
@@ -203,7 +231,7 @@ public class GetAbSomeObjectA : ModuleCmdlet
 }
 ```
 
-#### Effect at runtime
+##### Effect at runtime
 
 ```output
 Get-AbSomeObjectA  <parms here>
@@ -234,13 +262,13 @@ public class GetSomeObjectA : ModuleCmdlet
 }
 ```
 
-#### Effect at runtime
+##### Effect at runtime
 
 ```output
 Get-AbSomeObjectA <parms here>
 
 Breaking changes in the cmdlet : Get-AbSomeObjectA
-The cmdlet 'Get-AbSomeObjectC' is replacing this cmdlet
+The cmdlet 'Get-AbSomeObjectB' is replacing this cmdlet
 ```
 
 #### There is not a replacement
@@ -259,11 +287,145 @@ public class GetSomeObjectA : ModuleCmdlet
 }
 ```
 
-#### Effect at runtime
+##### Effect at runtime
 
 ```output
-Get-SomeObjectB <params here>
+Get-AbSomeObjectA <params here>
 
-Breaking changes in the cmdlet : Get-SomeObjectB
+Breaking changes in the cmdlet : Get-AbSomeObjectA
 The cmdlet is being deprecated. There will be no replacement for it.
+```
+
+### ParameterBreakingChangeAttribute
+
+This attribute should be used when the parameters for a command are changing.
+
+#### Being mandatory
+
+```csharp
+[Cmdlet(VerbsCommon.Get, "AbSomeObjectA"), OutputType(typeof(Foo))]
+public class GetSomeObjectA : ModuleCmdlet
+{
+    /// <summary>
+    /// Gets or sets the name for the object.
+    /// </summary>
+    [Parameter(HelpMessage = "The name for the object.", Mandatory = false)]
+    [ParameterBreakingChange(nameof(Name), IsBecomingMandatory = true)]
+    [ValidateNotNullOrEmpty]
+    public string Name { get; set; }
+
+    /// <summary>
+    /// Performs the actions associated with the command.
+    /// </summary>
+    protected override void PerformCmdlet()
+    {
+    }
+}
+```
+
+##### Effect at runtime
+
+```output
+Get-AbSomeObjectA <params here>
+
+Breaking changes in the cmdlet : Get-AbSomeObjectA
+ - The parameter 'Name' is becoming mandatory
+```
+
+#### Being replaced
+
+```csharp
+[Cmdlet(VerbsCommon.Get, "AbSomeObjectA"), OutputType(typeof(Foo))]
+public class GetSomeObjectA : ModuleCmdlet
+{
+    /// <summary>
+    /// Gets or sets the name for the object.
+    /// </summary>
+    [Parameter(HelpMessage = "The name for the object.", Mandatory = false)]
+    [ParameterBreakingChange(nameof(Name), IsBecomingMandatory = true, ReplacementParameterName = "ObjectId")]
+    [ValidateNotNullOrEmpty]
+    public string Name { get; set; }
+
+    /// <summary>
+    /// Performs the actions associated with the command.
+    /// </summary>
+    protected override void PerformCmdlet()
+    {
+    }
+}
+```
+
+##### Effect at runtime
+
+```output
+Get-AbSomeObjectA <params here>
+
+Breaking changes in the cmdlet : Get-AbSomeObjectA
+ - The parameter 'Name' is  being replaced by mandatory parameter 'ObjectId'
+```
+
+#### Changing type
+
+```csharp
+[Cmdlet(VerbsCommon.Get, "AbSomeObjectA"), OutputType(typeof(Foo))]
+public class GetSomeObjectA : ModuleCmdlet
+{
+    /// <summary>
+    /// Gets or sets the name for the object.
+    /// </summary>
+    [Parameter(HelpMessage = "The name for the object.", Mandatory = false)]
+    [ParameterBreakingChange(nameof(Name), NewParameterTypeName = "MyName", OldParamaterType = typeof(string))]
+    [ValidateNotNullOrEmpty]
+    public string Name { get; set; }
+
+    /// <summary>
+    /// Performs the actions associated with the command.
+    /// </summary>
+    protected override void PerformCmdlet()
+    {
+    }
+}
+```
+
+##### Effect at runtime
+
+```output
+Get-AbSomeObjectA <params here>
+
+Breaking changes in the cmdlet : Get-AbSomeObjectA
+ - The parameter 'Name' is changing
+    The type of the parameter is changing from 'string' to 'MyName'.
+```
+
+#### Simple message
+
+```csharp
+[Cmdlet(VerbsCommon.Get, "AbSomeObjectA"), OutputType(typeof(Foo))]
+public class GetSomeObjectA : ModuleCmdlet
+{
+    /// <summary>
+    /// Gets or sets the name for the object.
+    /// </summary>
+    [Parameter(HelpMessage = "The name for the object.", Mandatory = false)]
+    [ParameterBreakingChange(nameof(Name), ChangeDescription = "This is a simple message.")]
+    [ValidateNotNullOrEmpty]
+    public string Name { get; set; }
+
+    /// <summary>
+    /// Performs the actions associated with the command.
+    /// </summary>
+    protected override void PerformCmdlet()
+    {
+    }
+}
+```
+
+##### Effect at runtime
+
+```output
+Get-AbSomeObjectA <params here>
+
+Breaking changes in the cmdlet : Get-AbSomeObjectA
+ - The parameter 'Name' is changing
+    Change description : This is a simple message.
 ```

--- a/docs/breaking-defined.md
+++ b/docs/breaking-defined.md
@@ -21,12 +21,115 @@ When this configuration is enabled no warning messages when be displayed when in
 ### Commands
 
 * Change in the `OutputType` or removal of the `OutputType` attribute
-  * Before making the change update the command with the [OutputBreakingChangeAttribute]()
+  * Update the command, to apply the [OutputBreakingChangeAttribute](breaking-defined.md#outputbreakingchangeattribute) attribute. 
 * Changing a command name without an alias to the original name
+  * Update the command, to apply the [CommandDeprecationAttribute](breaking-defined.md#commanddeprecationattribute) attribute.
 * Removing an attribute option such as `SupportsPaging` or `SupportShouldProcess`
+  * Update the command, to apply the [BreakingChangeAttribute](breaking-defined.md#breakingchangeattribute) attribute specifically mentioning the parameter that be removed.
 * Removing or changing a command alias
+  * Update the command, to apply the [BreakingChangeAttribute](breaking-defined.md#breakingchangeattribute) attribute specifically mentioning the alias that will be depcreated.
+
+### Parameters
+
+* Adding a required parameter to an existing parameter set
+* Changing parameter order for parameter sets with ordered parameters
+* Changing the name of a parameter without an alias to the original parameter name
+* Making parameter validation more exclusive (e.g., removing values from a `ValidateSet`)
+* Removing a parameter
+* Removing or changing a parameter alias
+* Removing or changing existing parameter attribute values
+
+### Types
+
+* Adding additional required properties
+* Adding required parameters, changing parameter names, or parameter types for methods or constructors
+* Changing property names without an accompanying alias to the original name
+* Changing return types of methods
+* Removing properties
 
 ## Examples
+
+### BreakingChangeAttribute
+
+This attribute should be used when making a breaking change that is not handled by one of the specialized attributes below.
+
+#### Simple message
+
+```csharp
+[BreakingChange("This is a simple message.")]
+[Cmdlet(VerbsCommon.Get, "AbSomeObjectA"), OutputType(typeof(Foo))]
+public class GetAbSomeObjectA : ModuleCmdlet
+{
+    /// <summary>
+    /// Performs the actions associated with the command.
+    /// </summary>
+    protected override void PerformCmdlet()
+    {
+    }
+}
+```
+
+#### Effect at runtime
+
+```output
+Get-AbSomeObjectA <parms here>
+
+Breaking changes in the cmdlet : Get-AbSomeObjectA
+ - This is a simple message
+```
+
+#### Simple message with version
+
+```csharp
+[BreakingChange("This is a simple message.", "2.0.0.0")]
+[Cmdlet(VerbsCommon.Get, "AbSomeObjectA"), OutputType(typeof(Foo))]
+public class GetAbSomeObjectA : ModuleCmdlet
+{
+    /// <summary>
+    /// Performs the actions associated with the command.
+    /// </summary>
+    protected override void PerformCmdlet()
+    {
+    }
+}
+```
+
+#### Effect at runtime
+
+```output
+Get-AbSomeObjectA <parms here>
+
+Breaking changes in the cmdlet : Get-AbSomeObjectA
+ - This is a simple message
+    The change is expected to take effect from the version : 2.0.0.0
+```
+
+#### Simple message with version and date
+
+```csharp
+[BreakingChange("This is a simple message.", "2.0.0.0", "07/01/2023")]
+[Cmdlet(VerbsCommon.Get, "AbSomeObjectA"), OutputType(typeof(Foo))]
+public class GetAbSomeObjectA : ModuleCmdlet
+{
+    /// <summary>
+    /// Performs the actions associated with the command.
+    /// </summary>
+    protected override void PerformCmdlet()
+    {
+    }
+}
+```
+
+#### Effect at runtime
+
+```output
+Get-AbSomeObjectA <parms here>
+
+Breaking changes in the cmdlet : Get-AbSomeObjectA
+ - This is a simple message
+    NOTE : This change will take effect on '07/01/2023'
+    The change is expected to take effect from the version : 2.0.0.0
+```
 
 ### OutputBreakingChangeAttribute
 
@@ -52,7 +155,7 @@ public class GetAbSomeObjectA : ModuleCmdlet
 
 ```output
 Get-AbSomeObjectA <parms here>
-...
+
 Breaking changes in the cmdlet : Get-AbSomeObjectA
  - The output type is changing from the existing type :'Foo' to the new type :'Dictionary<String, Foo>'
 ```
@@ -77,7 +180,7 @@ public class GetAbSomeObjectA : ModuleCmdlet
 
 ```output
 Get-AbSomeObjectA <parms here>
-...
+
 Breaking changes in the cmdlet : Get-AbSomeObjectA
  - The output type 'Foo' is changing
  - The following properties are being added to the output type :
@@ -104,9 +207,63 @@ public class GetAbSomeObjectA : ModuleCmdlet
 
 ```output
 Get-AbSomeObjectA  <parms here>
-...
+
 Breaking changes in the cmdlet : Get-AbSomeObjectA
  - The output type 'Foo' is changing
  - The following properties in the output type are being deprecated :
     'Prop3' 'Prop4'
+```
+
+### CommandDeprecationAttribute
+
+This attirbute should be used when deprecating an alias or command.
+
+#### There is a replacement
+
+```csharp
+[CmdletDeprecation(ReplacementCmdletName = "Get-AbSomeObjectB")]
+[Cmdlet(VerbsCommon.Get, "AbSomeObjectA"), OutputType(typeof(Foo))]
+public class GetSomeObjectA : ModuleCmdlet
+{
+    /// <summary>
+    /// Performs the actions associated with the command.
+    /// </summary>
+    protected override void PerformCmdlet()
+    {
+    }
+}
+```
+
+#### Effect at runtime
+
+```output
+Get-AbSomeObjectA <parms here>
+
+Breaking changes in the cmdlet : Get-AbSomeObjectA
+The cmdlet 'Get-AbSomeObjectC' is replacing this cmdlet
+```
+
+#### There is not a replacement
+
+```csharp
+[CmdletDeprecation]
+[Cmdlet(VerbsCommon.Get, "AbSomeObjectA"), OutputType(typeof(Foo))]
+public class GetSomeObjectA : ModuleCmdlet
+{
+    /// <summary>
+    /// Performs the actions associated with the command.
+    /// </summary>
+    protected override void PerformCmdlet()
+    {
+    }
+}
+```
+
+#### Effect at runtime
+
+```output
+Get-SomeObjectB <params here>
+
+Breaking changes in the cmdlet : Get-SomeObjectB
+The cmdlet is being deprecated. There will be no replacement for it.
 ```

--- a/src/PowerShell/Attributes/BreakingChangeAttribute.cs
+++ b/src/PowerShell/Attributes/BreakingChangeAttribute.cs
@@ -44,7 +44,7 @@
         /// Initializes a new instance of the <see cref="BreakingChangeAttribute" /> class.
         /// </summary>
         /// <param name="message">The message that describes the breaking change.</param>
-        protected BreakingChangeAttribute(string message)
+        public BreakingChangeAttribute(string message)
         {
             message.AssertNotEmpty(nameof(message));
 
@@ -56,7 +56,7 @@
         /// </summary>
         /// <param name="message">The message that describes the breaking change.</param>
         /// <param name="deprecateByVersion">The version where the change will be required.</param>
-        protected BreakingChangeAttribute(string message, string deprecateByVersion)
+        public BreakingChangeAttribute(string message, string deprecateByVersion)
         {
             message.AssertNotEmpty(nameof(message));
             deprecateByVersion.AssertNotEmpty(nameof(deprecateByVersion));
@@ -71,7 +71,7 @@
         /// <param name="message">The message that describes the breaking change.</param>
         /// <param name="deprecateByVersion">The version where the change will be required.</param>
         /// <param name="changeInEfectByDate">The date when the change will be required.</param>
-        protected BreakingChangeAttribute(string message, string deprecateByVersion, string changeInEfectByDate)
+        public BreakingChangeAttribute(string message, string deprecateByVersion, string changeInEfectByDate)
         {
             deprecateByVersion.AssertNotEmpty(nameof(deprecateByVersion));
             changeInEfectByDate.AssertNotEmpty(nameof(changeInEfectByDate));


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

## Description

Through this pull request more examples of breaking changes are being added to the documentation.

## Checklist

- [x] I have read the [submitting changes](../CONTRIBUTING.md#submitting-changes) section from the [contributing](../CONTRIBUTING.md) article.
- [x] Updates have been made to the [change log](../CHANGELOG.md) that reflect what is changing.
  - A snippet outlining the change(s) made in the PR should be written under the `## Upcoming release` header -- no new version header should be added.
- [x] When applicable, if the changes in this pull request are introducing breaking changes, as defined [here](../docs/breaking-defined.md), the following has been completed:
  - [x] Details for the breaking change have been documented under the `## Future` header in the [breaking changes](../docs/breaking-changes.md) article.
  - [x] The appropriate breaking change attributes have been implemented.
- [x] When applicable, the markdown help has been regenerated using the process documented [here](../docs/help-generation.md#updating-all-markdown-files-in-a-module)
- [x] When applicable, the changes made in the pull request have proper test coverage.
