### PR TITLE
Configuration provider update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,10 @@
 
 # Change Log
 
+## Upcoming Release
+
+* Resolved configuration issue when using the module with an Azure Function app [#9](https://github.com/automationbrew/autobrew-powershell/issues/9)
+
 ## 1.0.1 - June 2022
 
 * Added the `Get-AbDelegatedAdminAccessAssignment` command to get delegated admin access assignments that exists for the given relationship.
@@ -31,4 +35,4 @@
 * Added the `New-AbRandomPassword` command to create a random secure password.
 * Added the `New-AbRiskyUser` command to create an Azure Active Directory user risk event using a Tor proxy.
 * Added the `Set-AbDelegatedAdminRelationshipRequest` command to update the request for the specified delegated admin relationship.
-* Resolved the `Microsoft.Extensions.Primitives` assembly conflict (#5)[https://github.com/automationbrew/autobrew-powershell/issues/5]  
+* Resolved the `Microsoft.Extensions.Primitives` assembly conflict [#5](https://github.com/automationbrew/autobrew-powershell/issues/5)


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

## Description

Through this pull request the following changes are being made to the configuration provider.

* Updating the provider to utilize a fallback location for the configuration file to address #9 

## Checklist

- [x] I have read the [submitting changes](../blob/main/CONTRIBUTING.md#submitting-changes) section from the [contributing](../blob/main/CONTRIBUTING.md) article.
- [x] Updates have been made to the [change log](../blob/main/CHANGELOG.md) that reflect what is changing.
  - A snippet outlining the change(s) made in the PR should be written under the `## Upcoming release` header -- no new version header should be added.
- [x] When applicable, if the changes in this pull request are introducing breaking changes, as defined [here](../blob/main/docs/breaking-defined.md), the following has been completed:
  - [x] Details for the breaking change have been documented under the `## Future` header in the [breaking changes](../blob/main/docs/breaking-changes.md) article.
  - [x] The appropriate breaking change attributes have been implemented.
- [ ] When applicable, the markdown help has been regenerated using the process documented [here](../blob/main/docs/help-generation.md#updating-all-markdown-files-in-a-module)
- [ ] When applicable, the changes made in the pull request have proper test coverage.
