### PR TITLE
Operation refinements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 
 * Added optional parameters `DevTestLabName`, `KeyVaultName`, `ResourceGroupName`, and `SubscriptionId` to [Add-AbEnvironment](https://github.com/automationbrew/autobrew-powershell/blob/main/docs/help/Add-AbEnvironment.md)
 * Added optional parameters `DevTestLabName`, `KeyVaultName`, `ResourceGroupName`, and `SubscriptionId` to [Set-AbEnvironment](https://github.com/automationbrew/autobrew-powershell/blob/main/docs/help/Set-AbEnvironment.md)
+* Introduced logic to handle a null reference exception when invoking the `Disconnect-AbAccount` command before a valid connection has been established
 * Introduced logic to validate `Run-AbAccount` has been invoked successfully with commands that require a valid connection
 * Prevent builtin environments from being updated using the [Set-AbEnvironment](https://github.com/automationbrew/autobrew-powershell/blob/main/docs/help/Set-AbEnvironment.md) command [#12](https://github.com/automationbrew/autobrew-powershell/issues/12)
 * Resolved could not load the `System.Runtime.CompilerServices.Unsafe` assembly when using the `New-AbAccessToken` command and PowerShell 5.1 [#17](https://github.com/automationbrew/autobrew-powershell/issues/17)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 
 * Added optional parameters `DevTestLabName`, `KeyVaultName`, `ResourceGroupName`, and `SubscriptionId` to [Add-AbEnvironment](https://github.com/automationbrew/autobrew-powershell/blob/main/docs/help/Add-AbEnvironment.md)
 * Added optional parameters `DevTestLabName`, `KeyVaultName`, `ResourceGroupName`, and `SubscriptionId` to [Set-AbEnvironment](https://github.com/automationbrew/autobrew-powershell/blob/main/docs/help/Set-AbEnvironment.md)
+* Introduced logic to validate `Run-AbAccount` has been invoked successfully with commands that require a valid connection
 * Prevent builtin environments from being updated using the [Set-AbEnvironment](https://github.com/automationbrew/autobrew-powershell/blob/main/docs/help/Set-AbEnvironment.md) command [#12](https://github.com/automationbrew/autobrew-powershell/issues/12)
 * Resolved could not load the `System.Runtime.CompilerServices.Unsafe` assembly when using the `New-AbAccessToken` command and PowerShell 5.1 [#17](https://github.com/automationbrew/autobrew-powershell/issues/17)
 * Resolved configuration issue when using the module with an Azure Function app [#9](https://github.com/automationbrew/autobrew-powershell/issues/9)

--- a/src/PowerShell/Ab.psd1
+++ b/src/PowerShell/Ab.psd1
@@ -138,6 +138,7 @@ PrivateData = @{
         # ReleaseNotes of this module
         ReleaseNotes = '* Added optional parameters `DevTestLabName`, `KeyVaultName`, `ResourceGroupName`, and `SubscriptionId` to [Add-AbEnvironment](https://github.com/automationbrew/autobrew-powershell/blob/main/docs/help/Add-AbEnvironment.md)
 * Added optional parameters `DevTestLabName`, `KeyVaultName`, `ResourceGroupName`, and `SubscriptionId` to [Set-AbEnvironment](https://github.com/automationbrew/autobrew-powershell/blob/main/docs/help/Set-AbEnvironment.md)
+* Introduced logic to handle a null reference exception when invoking the `Disconnect-AbAccount` command before a valid connection has been established
 * Introduced logic to validate `Run-AbAccount` has been invoked successfully with commands that require a valid connection
 * Prevent builtin environments from being updated using the [Set-AbEnvironment](https://github.com/automationbrew/autobrew-powershell/blob/main/docs/help/Set-AbEnvironment.md) command [#12](https://github.com/automationbrew/autobrew-powershell/issues/12)
 * Resolved could not load the `System.Runtime.CompilerServices.Unsafe` assembly when using the `New-AbAccessToken` command and PowerShell 5.1 [#17](https://github.com/automationbrew/autobrew-powershell/issues/17)

--- a/src/PowerShell/Ab.psd1
+++ b/src/PowerShell/Ab.psd1
@@ -138,6 +138,7 @@ PrivateData = @{
         # ReleaseNotes of this module
         ReleaseNotes = '* Added optional parameters `DevTestLabName`, `KeyVaultName`, `ResourceGroupName`, and `SubscriptionId` to [Add-AbEnvironment](https://github.com/automationbrew/autobrew-powershell/blob/main/docs/help/Add-AbEnvironment.md)
 * Added optional parameters `DevTestLabName`, `KeyVaultName`, `ResourceGroupName`, and `SubscriptionId` to [Set-AbEnvironment](https://github.com/automationbrew/autobrew-powershell/blob/main/docs/help/Set-AbEnvironment.md)
+* Introduced logic to validate `Run-AbAccount` has been invoked successfully with commands that require a valid connection
 * Prevent builtin environments from being updated using the [Set-AbEnvironment](https://github.com/automationbrew/autobrew-powershell/blob/main/docs/help/Set-AbEnvironment.md) command [#12](https://github.com/automationbrew/autobrew-powershell/issues/12)
 * Resolved could not load the `System.Runtime.CompilerServices.Unsafe` assembly when using the `New-AbAccessToken` command and PowerShell 5.1 [#17](https://github.com/automationbrew/autobrew-powershell/issues/17)
 * Resolved configuration issue when using the module with an Azure Function app [#9](https://github.com/automationbrew/autobrew-powershell/issues/9)

--- a/src/PowerShell/Commands/DisconnectAbAccount.cs
+++ b/src/PowerShell/Commands/DisconnectAbAccount.cs
@@ -25,7 +25,13 @@
                 throw new ModuleException("Reload the module becuase there was an issue with the token cache.", ModuleExceptionCategory.Authentication);
             }
 
-            ModuleAccount account = ModuleSession.Instance.Context.Account;
+            ModuleAccount account = ModuleSession.Instance?.Context?.Account;
+
+            if (account == null)
+            {
+                ModuleSession.Instance.Context = null;
+                return;
+            }
 
             await ConfirmActionAsync(
                 string.Format(CultureInfo.InvariantCulture, Resources.LogoutTarget, account.Username),
@@ -37,6 +43,7 @@
 
                     WriteObject(account);
                 }).ConfigureAwait(false);
+
         }
     }
 }

--- a/src/PowerShell/Commands/GetAbAccessToken.cs
+++ b/src/PowerShell/Commands/GetAbAccessToken.cs
@@ -18,9 +18,7 @@
         [Parameter(HelpMessage = "The scopes to be used for authentication.", Mandatory = true)]
         public string[] Scopes { get; set; }
 
-        /// <summary>
-        /// Gets a flag that indicates whether the connection should be validated before processing the command.
-        /// </summary>
+        /// <inheritdoc/>
         public override bool ValidateConnection => true;
 
         /// <summary>

--- a/src/PowerShell/Commands/GetAbDelegatedAdminAccessAssignment.cs
+++ b/src/PowerShell/Commands/GetAbDelegatedAdminAccessAssignment.cs
@@ -25,6 +25,9 @@
         [Parameter(HelpMessage = "The identifier for the delegated admin relationship.", Mandatory = true)]
         public string RelationshipId { get; set; }
 
+        /// <inheritdoc/>
+        public override bool ValidateConnection => true;
+
         /// <summary>
         /// Performs the actions associated with the command.
         /// </summary>

--- a/src/PowerShell/Commands/GetAbDelegatedAdminRelationship.cs
+++ b/src/PowerShell/Commands/GetAbDelegatedAdminRelationship.cs
@@ -18,6 +18,9 @@
         [ValidateNotNullOrEmpty]
         public string RelationshipId { get; set; }
 
+        /// <inheritdoc/>
+        public override bool ValidateConnection => true;
+
         /// <summary>
         /// Performs the actions associated with the command.
         /// </summary>

--- a/src/PowerShell/Commands/GetAbDelegatedAdminTenant.cs
+++ b/src/PowerShell/Commands/GetAbDelegatedAdminTenant.cs
@@ -19,6 +19,9 @@
         [ValidatePattern(@"^(\{){0,1}[0-9a-fA-F]{8}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{12}(\}){0,1}$", Options = RegexOptions.Compiled | RegexOptions.IgnoreCase)]
         public string Tenant { get; set; }
 
+        /// <inheritdoc/>
+        public override bool ValidateConnection => true;
+
         /// <summary>
         /// Performs the actions associated with the command.
         /// </summary>

--- a/src/PowerShell/Commands/NewAbDelegatedAdminAccessAssignment.cs
+++ b/src/PowerShell/Commands/NewAbDelegatedAdminAccessAssignment.cs
@@ -32,6 +32,9 @@
         [Parameter(HelpMessage = "The unified roles to be included in the access assignment.", Mandatory = true)]
         public string[] UnifiedRoles { get; set; }
 
+        /// <inheritdoc/>
+        public override bool ValidateConnection => true;
+
         /// <summary>
         /// Performs the actions associated with the command.
         /// </summary>

--- a/src/PowerShell/Commands/NewAbDelegatedAdminRelationship.cs
+++ b/src/PowerShell/Commands/NewAbDelegatedAdminRelationship.cs
@@ -38,6 +38,9 @@
         [Parameter(HelpMessage = "The unified roles for the delegated admin relationship.", Mandatory = true)]
         public string[] UnifiedRoles { get; set; }
 
+        /// <inheritdoc/>
+        public override bool ValidateConnection => true;
+
         /// <summary>
         /// Performs the actions associated with the command.
         /// </summary>

--- a/src/PowerShell/Commands/NewAbDelegatedAdminRelationshipRequest.cs
+++ b/src/PowerShell/Commands/NewAbDelegatedAdminRelationshipRequest.cs
@@ -18,6 +18,9 @@
         [ValidateNotNullOrEmpty]
         public string RelationshipId { get; set; }
 
+        /// <inheritdoc/>
+        public override bool ValidateConnection => true;
+
         /// <summary>
         /// Performs the actions associated with the command.
         /// </summary>

--- a/src/PowerShell/Commands/NewAbRiskyUser.cs
+++ b/src/PowerShell/Commands/NewAbRiskyUser.cs
@@ -63,6 +63,9 @@
         [ValidatePattern(@"^(?("")("".+?(?<!\\)""@)|(([0-9a-z]((\.(?!\.))|[-!#\$%&'\*\+/=\?\^`\{\}\|~\w])*)(?<=[0-9a-z])@))(?(\[)(\[(\d{1,3}\.){3}\d{1,3}\])|(([0-9a-z][-0-9a-z]*[0-9a-z]*\.)+[a-z0-9][\-a-z0-9]{0,22}[a-z0-9]))$", Options = RegexOptions.IgnoreCase)]
         public string UserPrincipalName { get; set; }
 
+        /// <inheritdoc/>
+        public override bool ValidateConnection => true;
+
         /// <summary>
         /// Performs the operations associated with the cmdlet.
         /// </summary>

--- a/src/PowerShell/Commands/SetAbDelegatedAdminRelationshipRequest.cs
+++ b/src/PowerShell/Commands/SetAbDelegatedAdminRelationshipRequest.cs
@@ -33,6 +33,9 @@
         [ValidatePattern(@"^(\{){0,1}[0-9a-fA-F]{8}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{12}(\}){0,1}$", Options = RegexOptions.Compiled | RegexOptions.IgnoreCase)]
         public string RequestId { get; set; }
 
+        /// <inheritdoc/>
+        public override bool ValidateConnection => true;
+
         /// <summary>
         /// Performs the actions associated with the command.
         /// </summary>


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

## Description

Through this pull request the following changes are being. 

- Introducing logic to validate `Run-AbAccount` has been successfully invoked for commands that require a valid connection
- Updating the `Disconnect-AbAccount` command to resolve a possible null reference exception that would have occurred when invoking the command before a valid connection had been established.

## Checklist

- [x] I have read the [submitting changes](../blob/main/CONTRIBUTING.md#submitting-changes) section from the [contributing](../blob/main/CONTRIBUTING.md) article.
- [x] Updates have been made to the [change log](../blob/main/CHANGELOG.md) that reflect what is changing.
  - A snippet outlining the change(s) made in the PR should be written under the `## Upcoming release` header -- no new version header should be added.
- [x] When applicable, if the changes in this pull request are introducing breaking changes, as defined [here](../blob/main/docs/breaking-defined.md), the following has been completed:
  - [x] Details for the breaking change have been documented under the `## Future` header in the [breaking changes](../blob/main/docs/breaking-changes.md) article.
  - [x] The appropriate breaking change attributes have been implemented.
- [x] When applicable, the markdown help has been regenerated using the process documented [here](../blob/main/docs/help-generation.md#updating-all-markdown-files-in-a-module)
- [x] When applicable, the changes made in the pull request have proper test coverage.
